### PR TITLE
Feat: Add Favourite & Project Preference API's to store and retrieve the details

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/lestrrat-go/iter v1.0.2
 	github.com/lestrrat-go/jwx/v2 v2.1.4
 	github.com/markbates/pkger v0.17.1
+	github.com/mileusna/useragent v1.3.5
 	github.com/onsi/ginkgo/v2 v2.23.4
 	github.com/onsi/gomega v1.37.0
 	github.com/spf13/viper v1.20.1

--- a/go.sum
+++ b/go.sum
@@ -148,6 +148,8 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-sqlite3 v1.14.22 h1:2gZY6PC6kBnID23Tichd1K+Z0oS6nE/XwU+Vz/5o4kU=
 github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
+github.com/mileusna/useragent v1.3.5 h1:SJM5NzBmh/hO+4LGeATKpaEX9+b4vcGg2qXGLiNGDws=
+github.com/mileusna/useragent v1.3.5/go.mod h1:3d8TOmwL/5I8pJjyVDteHtgDGcefrFUX4ccGOMKNYYc=
 github.com/moby/docker-image-spec v1.3.1 h1:jMKff3w6PgbfSa69GfNg+zN/XLhfXJGnEx3Nl2EsFP0=
 github.com/moby/docker-image-spec v1.3.1/go.mod h1:eKmb5VW8vQEh/BAr2yvVNvuiJuY6UIocYsFu/DxxRpo=
 github.com/moby/term v0.5.0 h1:xt8Q1nalod/v7BqbG21f8mQPqH+xAaC9C3N3wfWbVP0=

--- a/pkg/api/handlers/handlers_test.go
+++ b/pkg/api/handlers/handlers_test.go
@@ -1054,31 +1054,6 @@ var _ = Describe("Handlers", func() {
 		})
 	})
 
-	Context("When the report project handler is invoked", func() {
-		It("should return all project names in ascending order", func() {
-			projectRows := sqlmock.NewRows([]string{"id", "name", "uuid"}).
-				AddRow(1, "ProjectA", "uuid-1").
-				AddRow(2, "ProjectF", "uuid-2").
-				AddRow(3, "ProjectZ", "uuid-3")
-
-			mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "project_details" ORDER BY name ASC`)).
-				WillReturnRows(projectRows)
-
-			gin.SetMode(gin.TestMode)
-			router := gin.Default()
-			handler := handlers.NewHandler(gormDb)
-			router.GET("/api/reports/projects", handler.GetProjectAll)
-
-			w := httptest.NewRecorder()
-			req, _ := http.NewRequest("GET", "/api/reports/projects", nil)
-			router.ServeHTTP(w, req)
-
-			Expect(w.Code).To(Equal(http.StatusOK))
-			expectedJSON := `{"projects":[{"id":1,"name":"ProjectA","uuid":"uuid-1"},{"id":2,"name":"ProjectF","uuid":"uuid-2"},{"id":3,"name":"ProjectZ","uuid":"uuid-3"}]}`
-			Expect(w.Body.String()).To(MatchJSON(expectedJSON))
-		})
-	})
-
 	Context("When a request is made to get a test summary by project name", func() {
 		It("should return the summary of test runs for the project", func() {
 			projectID := "1"

--- a/pkg/api/handlers/project/project.go
+++ b/pkg/api/handlers/project/project.go
@@ -1,0 +1,98 @@
+package project
+
+import (
+	"fmt"
+	"gorm.io/gorm/clause"
+	"log"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/guidewire/fern-reporter/pkg/models"
+	"gorm.io/gorm"
+)
+
+type ProjectHandler struct {
+	db *gorm.DB
+}
+
+// NewProjectHandler initializes ProjectHandler
+func NewProjectHandler(db *gorm.DB) *ProjectHandler {
+	return &ProjectHandler{db: db}
+}
+
+func (h *ProjectHandler) CreateProject(c *gin.Context) {
+	var project models.ProjectDetails
+
+	if err := c.ShouldBindJSON(&project); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	if err := h.db.Clauses(clause.Returning{}).Create(&project).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create project"})
+		return
+	}
+	log.Printf("Created project, Name: %s, UUID: %s", project.Name, project.UUID)
+	c.JSON(http.StatusCreated, project)
+}
+
+func (h *ProjectHandler) UpdateProject(c *gin.Context) {
+	id := c.Param("uuid")
+	var project models.ProjectDetails
+
+	if err := h.db.Where("uuid = ?", id).First(&project).Error; err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Project not found"})
+		return
+	}
+
+	if err := c.ShouldBindJSON(&project); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	if err := h.db.Save(&project).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update project"})
+		return
+	}
+
+	log.Printf("Updated project, Name: %s, UUID: %s", project.Name, project.UUID)
+	c.JSON(http.StatusOK, project)
+}
+
+func (h *ProjectHandler) DeleteProject(c *gin.Context) {
+	uuid := c.Param("uuid")
+
+	if err := h.db.Where("uuid = ?", uuid).Delete(&models.ProjectDetails{}).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to delete project"})
+		return
+	}
+
+	log.Printf("Deleted project, UUID: %s", uuid)
+	c.JSON(http.StatusOK, gin.H{"message": fmt.Sprintf("Project ID %s deleted", uuid)})
+}
+
+func (h *ProjectHandler) GetAllProjects(c *gin.Context) {
+	var projects []models.ProjectDetails
+
+	if err := h.db.Order("name ASC").Find(&projects).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Error fetching projects"})
+		return
+	}
+
+	c.JSON(http.StatusOK, projects)
+}
+
+func (h *ProjectHandler) GetAllProjectsForReport(c *gin.Context) {
+	var projects []struct {
+		ID   uint64 `json:"id"`
+		Name string `json:"name"`
+		UUID string `json:"uuid"`
+	}
+	h.db.Table("project_details").
+		Order("name ASC").
+		Find(&projects)
+
+	c.JSON(http.StatusOK, gin.H{
+		"projects": projects,
+	})
+}

--- a/pkg/api/handlers/project/project_suite_test.go
+++ b/pkg/api/handlers/project/project_suite_test.go
@@ -1,0 +1,13 @@
+package project_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestHandlers(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Project Suite")
+}

--- a/pkg/api/handlers/project/project_test.go
+++ b/pkg/api/handlers/project/project_test.go
@@ -1,0 +1,239 @@
+package project_test
+
+import (
+	"bytes"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/gin-gonic/gin"
+	"github.com/guidewire/fern-reporter/pkg/api/handlers/project"
+	"github.com/guidewire/fern-reporter/pkg/models"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"time"
+)
+
+var (
+	db     *sql.DB
+	gormDb *gorm.DB
+	mock   sqlmock.Sqlmock
+	err    error
+)
+
+var _ = BeforeEach(func() {
+	db, mock, err = sqlmock.New()
+	Expect(err).NotTo(HaveOccurred())
+
+	dialector := postgres.New(postgres.Config{
+		DSN:                  "sqlmock_db_0",
+		DriverName:           "postgres",
+		Conn:                 db,
+		PreferSimpleProtocol: true,
+	})
+	gormDb, err = gorm.Open(dialector, &gorm.Config{})
+	Expect(err).NotTo(HaveOccurred())
+})
+
+var _ = AfterEach(func() {
+	mock.ExpectClose()
+	err := db.Close()
+	if err != nil {
+		fmt.Printf("Unable to close the db connection %s", err.Error())
+	}
+})
+
+var _ = Describe("Project Handlers", func() {
+	Context("When the report project handler is invoked", func() {
+		It("should return all project names in ascending order", func() {
+			projectRows := sqlmock.NewRows([]string{"id", "name", "uuid"}).
+				AddRow(1, "ProjectA", "uuid-1").
+				AddRow(2, "ProjectF", "uuid-2").
+				AddRow(3, "ProjectZ", "uuid-3")
+
+			mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "project_details" ORDER BY name ASC`)).
+				WillReturnRows(projectRows)
+
+			gin.SetMode(gin.TestMode)
+			router := gin.Default()
+			handler := project.NewProjectHandler(gormDb)
+			router.GET("/api/reports/projects", handler.GetAllProjectsForReport)
+
+			w := httptest.NewRecorder()
+			req, _ := http.NewRequest("GET", "/api/reports/projects", nil)
+			router.ServeHTTP(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusOK))
+			expectedJSON := `{"projects":[{"id":1,"name":"ProjectA","uuid":"uuid-1"},{"id":2,"name":"ProjectF","uuid":"uuid-2"},{"id":3,"name":"ProjectZ","uuid":"uuid-3"}]}`
+			Expect(w.Body.String()).To(MatchJSON(expectedJSON))
+		})
+	})
+
+	Context("when save project is invoked", func() {
+		projectID := "96ad860-2a9a-504f-8861-aeafd0b2ae29"
+		projRequest := models.ProjectDetails{
+			Name:     "First Project",
+			TeamName: "Team A",
+			Comment:  "Sample Comment",
+		}
+		It("with proper details, it should create one and return project object back", func() {
+
+			reqBody, err := json.Marshal(projRequest)
+			if err != nil {
+				fmt.Printf("Error serializing SuiteRuns: %v", err)
+				return
+			}
+
+			mock.ExpectBegin()
+			mock.ExpectQuery(regexp.QuoteMeta(`INSERT INTO "project_details" ("name","team_name","comment","updated_at") VALUES ($1,$2,$3,$4) RETURNING *`)).
+				WithArgs(projRequest.Name, projRequest.TeamName, projRequest.Comment, sqlmock.AnyArg()).
+				WillReturnRows(
+					sqlmock.NewRows([]string{"id", "uuid", "name", "team_name", "comment", "created_at", "updated_at"}).
+						AddRow(1, projectID, projRequest.Name, projRequest.TeamName, projRequest.Comment, time.Now(), time.Now()),
+				)
+
+			mock.ExpectCommit()
+
+			req := httptest.NewRequest(http.MethodPost, "/api/project", bytes.NewBuffer([]byte(reqBody)))
+			req.Header.Set("Content-Type", "application/json")
+
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Request = req
+			handler := project.NewProjectHandler(gormDb)
+
+			handler.CreateProject(c)
+			Expect(w.Code).To(Equal(201))
+
+			var project models.ProjectDetails
+			if err := json.NewDecoder(w.Body).Decode(&project); err != nil {
+				Fail(err.Error())
+			}
+
+			Expect(project.UUID).To(Equal(projectID))
+			Expect(project.Name).To(Equal(projRequest.Name))
+			Expect(project.TeamName).To(Equal(projRequest.TeamName))
+			Expect(project.Comment).To(Equal(projRequest.Comment))
+		})
+	})
+
+	Context("when update project is invoked", func() {
+		projectID := "96ad860-2a9a-504f-8861-aeafd0b2ae29"
+		projRequest := models.ProjectDetails{
+			ID:       1,
+			UUID:     projectID,
+			Name:     "First Project",
+			TeamName: "Team A",
+			Comment:  "Sample Comment",
+		}
+		It("with proper details, it should update one and return project object back", func() {
+
+			projectRows := sqlmock.NewRows([]string{"id", "uuid", "name", "team_name", "comment"}).
+				AddRow(1, projectID, projRequest.Name, projRequest.TeamName, projRequest.Comment)
+
+			reqBody, err := json.Marshal(projRequest)
+			if err != nil {
+				fmt.Printf("Error serializing SuiteRuns: %v", err)
+				return
+			}
+
+			mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "project_details" WHERE uuid = $1 ORDER BY "project_details"."id" LIMIT $2`)).
+				WithArgs(projectID, 1).
+				WillReturnRows(projectRows)
+
+			mock.ExpectBegin()
+			mock.ExpectExec(regexp.QuoteMeta(`UPDATE "project_details" SET "name"=$1,"team_name"=$2,"comment"=$3,"created_at"=$4,"updated_at"=$5 WHERE "id" = $6`)).
+				WithArgs(projRequest.Name, projRequest.TeamName, projRequest.Comment, sqlmock.AnyArg(), sqlmock.AnyArg(), 1).
+				WillReturnResult(sqlmock.NewResult(0, 1))
+			mock.ExpectCommit()
+
+			req := httptest.NewRequest(http.MethodPost, "/api/project", bytes.NewBuffer([]byte(reqBody)))
+			req.Header.Set("Content-Type", "application/json")
+
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Params = append(c.Params, gin.Param{Key: "uuid", Value: projectID})
+			c.Request = req
+			handler := project.NewProjectHandler(gormDb)
+
+			handler.UpdateProject(c)
+			Expect(w.Code).To(Equal(200))
+
+			var project models.ProjectDetails
+			if err := json.NewDecoder(w.Body).Decode(&project); err != nil {
+				Fail(err.Error())
+			}
+			Expect(project.Name).To(Equal(projRequest.Name))
+			Expect(project.TeamName).To(Equal(projRequest.TeamName))
+			Expect(project.Comment).To(Equal(projRequest.Comment))
+		})
+		It("for invalid project UUID, it should not update return 404", func() {
+
+			reqBody, err := json.Marshal(projRequest)
+			if err != nil {
+				fmt.Printf("Error serializing SuiteRuns: %v", err)
+				return
+			}
+
+			mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "project_details" WHERE uuid = $1 ORDER BY "project_details"."id" LIMIT $2`)).
+				WithArgs(projectID, 1).
+				WillReturnError(gorm.ErrRecordNotFound)
+
+			req := httptest.NewRequest(http.MethodPost, "/api/project", bytes.NewBuffer([]byte(reqBody)))
+			req.Header.Set("Content-Type", "application/json")
+
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Params = append(c.Params, gin.Param{Key: "uuid", Value: projectID})
+			c.Request = req
+			handler := project.NewProjectHandler(gormDb)
+
+			handler.UpdateProject(c)
+			Expect(w.Code).To(Equal(404))
+			Expect(w.Body.String()).To(Equal(`{"error":"Project not found"}`))
+		})
+	})
+
+	Context("when delete project is invoked", func() {
+		projectID := "96ad860-2a9a-504f-8861-aeafd0b2ae29"
+		projRequest := models.ProjectDetails{
+			ID:       1,
+			UUID:     projectID,
+			Name:     "First Project",
+			TeamName: "Team A",
+			Comment:  "Sample Comment",
+		}
+		It("with proper details, it should delete 200", func() {
+
+			reqBody, err := json.Marshal(projRequest)
+			if err != nil {
+				fmt.Printf("Error serializing SuiteRuns: %v", err)
+				return
+			}
+
+			mock.ExpectBegin()
+			mock.ExpectExec(regexp.QuoteMeta(`DELETE FROM "project_details" WHERE uuid = $1`)).
+				WithArgs(projectID).
+				WillReturnResult(sqlmock.NewResult(0, 1))
+			mock.ExpectCommit()
+
+			req := httptest.NewRequest(http.MethodPost, "/api/project", bytes.NewBuffer([]byte(reqBody)))
+			req.Header.Set("Content-Type", "application/json")
+
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Params = append(c.Params, gin.Param{Key: "uuid", Value: projectID})
+			c.Request = req
+			handler := project.NewProjectHandler(gormDb)
+
+			handler.DeleteProject(c)
+			Expect(w.Code).To(Equal(200))
+			Expect(w.Body.String()).To(Equal(`{"message":"Project ID 96ad860-2a9a-504f-8861-aeafd0b2ae29 deleted"}`))
+		})
+	})
+})

--- a/pkg/api/handlers/user/user_preference.go
+++ b/pkg/api/handlers/user/user_preference.go
@@ -1,0 +1,433 @@
+package user
+
+import (
+	"errors"
+	"fmt"
+	"github.com/gin-gonic/gin"
+	"github.com/guidewire/fern-reporter/pkg/models"
+	"github.com/guidewire/fern-reporter/pkg/utils"
+	"gorm.io/gorm"
+	"log"
+	"net/http"
+)
+
+type FavouriteProjectRequest struct {
+	Favourite string `json:"favourite"`
+}
+
+type UserPreferenceRequest struct {
+	IsDark   bool   `json:"is_dark"`
+	Timezone string `json:"timezone"`
+}
+
+type PreferredRequest struct {
+	Preferred []struct {
+		GroupID   uint64   `json:"group_id"` // will be empty for new group
+		GroupName string   `json:"group_name"`
+		Projects  []string `json:"projects"` // list of project UUIDs
+	} `json:"preferred"`
+}
+
+type DeletePreferredRequest struct {
+	Preferred []struct {
+		GroupID uint64 `json:"group_id"`
+	} `json:"preferred"`
+}
+
+type ProjectSummary struct {
+	UUID string `json:"uuid"`
+	Name string `json:"name"`
+}
+
+type GroupedProjects struct {
+	GroupID   uint64           `json:"group_id"`
+	GroupName string           `json:"group_name"`
+	Projects  []ProjectSummary `json:"projects"`
+}
+
+type PreferenceResponse struct {
+	Cookie    string            `json:"cookie"`
+	Preferred []GroupedProjects `json:"preferred"`
+}
+
+type UserHandler struct {
+	db *gorm.DB
+}
+
+// NewProjectHandler initializes ProjectHandler
+func NewUserHandler(db *gorm.DB) *UserHandler {
+	return &UserHandler{db: db}
+}
+
+func (h *UserHandler) SaveFavouriteProject(c *gin.Context) {
+	var favouriteRequest FavouriteProjectRequest
+	ucookie, _ := c.Cookie(utils.CookieName)
+
+	if err := c.ShouldBindJSON(&favouriteRequest); err != nil {
+		fmt.Print(err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return // Stop further processing if there is a binding error
+	}
+
+	// Check if user exists
+	user, err := GetUserObject(h, ucookie)
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": fmt.Sprintf("User ID not found: %v", err)})
+	}
+
+	var project models.ProjectDetails
+	if err := h.db.Where("uuid = ?", favouriteRequest.Favourite).First(&project).Error; err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": fmt.Sprintf("Project id %s not found", favouriteRequest.Favourite)})
+		return
+	}
+
+	// check if favourite entry exists for the user
+	var count int64 = 1
+	if err := h.db.Table("preferred_projects").Where("user_id = ? and project_id = ?", user.ID, project.ID).Count(&count).Error; err != nil {
+		c.JSON(http.StatusConflict, gin.H{"error": fmt.Sprintf("favourite project %s already configured for the user", favouriteRequest.Favourite)})
+		return
+	}
+
+	if count <= 0 {
+		userPreferredProject := models.PreferredProject{
+			UserID:    user.ID,
+			ProjectID: project.ID,
+			GroupID:   nil, // ungrouped
+			User:      user,
+			Project:   project,
+		}
+
+		// Save favourite project to DB
+		if err := h.db.Omit("User", "Project").Save(&userPreferredProject).Error; err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "error saving record or favourite already saved"})
+			return
+		}
+		log.Printf("Saved favourite project %s, for the user cookie %s", project.UUID, ucookie)
+
+	}
+	c.JSON(http.StatusCreated, gin.H{
+		"status": "success",
+	})
+}
+
+func (h *UserHandler) DeleteFavouriteProject(c *gin.Context) {
+	projectUUID := c.Param("projectUUID")
+	ucookie, _ := c.Cookie(utils.CookieName)
+
+	// Check if user exists
+	user, err := GetUserObject(h, ucookie)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("User ID not found: %v", err)})
+	}
+
+	var project models.ProjectDetails
+	if err := h.db.Where("uuid = ?", projectUUID).First(&project).Error; err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": fmt.Sprintf("Project %s not found", projectUUID)})
+		return
+	}
+
+	userPreferredProject := models.PreferredProject{
+		UserID:    user.ID,
+		ProjectID: project.ID,
+		GroupID:   nil, // ungrouped
+	}
+
+	// Delete favourite from DB
+	if err := h.db.Where("user_id = ? and project_id = ?", user.ID, project.ID).Delete(&userPreferredProject).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Error deleting project"})
+		return
+	}
+	log.Printf("favourite project %s deleted successfully for the user cookie %s", project.UUID, ucookie)
+	c.JSON(http.StatusOK, gin.H{"message": fmt.Sprintf("Favourite Project %s deleted successfully", project.UUID)})
+}
+
+func (h *UserHandler) SaveUserPreference(c *gin.Context) {
+	var preference UserPreferenceRequest
+	ucookie, _ := c.Cookie(utils.CookieName)
+
+	if err := c.ShouldBindJSON(&preference); err != nil {
+		fmt.Print(err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return // Stop further processing if there is a binding error
+	}
+
+	// Check if user exists
+	_, err := GetUserObject(h, ucookie)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("User ID not found: %v", err)})
+	}
+
+	// Save Preference to DB
+	result := h.db.Model(&models.AppUser{}).
+		Where("cookie = ?", ucookie).
+		Updates(models.AppUser{
+			IsDark:   preference.IsDark,
+			Timezone: preference.Timezone,
+		})
+
+	if result.Error != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "error updating preference"})
+		return
+	}
+
+	// If no rows were affected, the cookie didn't exist — optionally create
+	if result.RowsAffected == 0 {
+		log.Printf("Not updated, user record not exists for the cookie %s", ucookie)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Not updated, user record not exists"})
+		return
+	}
+
+	log.Printf("user preference updated for the cookie %s", ucookie)
+	c.JSON(http.StatusAccepted, gin.H{
+		"status": "success",
+	})
+}
+
+func (h *UserHandler) GetUserPreference(c *gin.Context) {
+	//ucookie := c.Param("ucookie")
+	ucookie, _ := c.Cookie(utils.CookieName)
+	var user models.AppUser
+
+	if err := h.db.Where("cookie = ?", ucookie).First(&user).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Error fetching User"})
+		return
+	}
+	c.JSON(http.StatusOK, user)
+}
+func (h *UserHandler) SavePreferredProject(c *gin.Context) {
+	var preferredRequest PreferredRequest
+	ucookie, _ := c.Cookie(utils.CookieName)
+
+	if err := c.ShouldBindJSON(&preferredRequest); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	// Remove duplicate project entries if there are any
+	var groupIDs []uint64
+	for i, group := range preferredRequest.Preferred {
+		seen := make(map[string]bool)
+		var uniqueProjects []string
+
+		for _, projectUUID := range group.Projects {
+			if !seen[projectUUID] {
+				seen[projectUUID] = true
+				uniqueProjects = append(uniqueProjects, projectUUID)
+			}
+		}
+		preferredRequest.Preferred[i].Projects = uniqueProjects
+		if group.GroupID != 0 { // Only consider existing groups (non-zero group_id)
+			groupIDs = append(groupIDs, group.GroupID)
+		}
+	}
+
+	// 1. Find the user
+	user, err := GetUserObject(h, ucookie)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("User ID not found: %v", err)})
+	}
+
+	// Begin transaction
+	tx := h.db.Begin()
+
+	// 2. Delete only PreferredProjects matching user_id and group_id in the request
+	if len(groupIDs) > 0 {
+		if err := tx.Where("user_id = ? AND group_id IN ?", user.ID, groupIDs).
+			Delete(&models.PreferredProject{}).Error; err != nil {
+			tx.Rollback()
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to clear preferences"})
+			return
+		}
+	}
+
+	// 3. Prepare all new preferred entries
+	var preferredEntries []models.PreferredProject
+
+	for _, group := range preferredRequest.Preferred {
+		var groupModel models.ProjectGroup
+
+		// Try to find the group first
+		err := tx.Where("user_id = ? AND group_id = ?", user.ID, group.GroupID).First(&groupModel).Error
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			// Create if it doesn't exist
+			groupModel = models.ProjectGroup{
+				GroupID:   group.GroupID,
+				UserID:    user.ID,
+				GroupName: group.GroupName,
+			}
+			if err := tx.Create(&groupModel).Error; err != nil {
+				tx.Rollback()
+				c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to create group '%s' ", err)})
+				return
+			}
+		} else if err != nil {
+			tx.Rollback()
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch group"})
+			return
+		}
+
+		for _, projectUUID := range group.Projects {
+			var project models.ProjectDetails
+			if err := tx.Where("uuid = ?", projectUUID).First(&project).Error; err != nil {
+				// Optionally skip or log; skipping here
+				continue
+			}
+
+			preferredEntries = append(preferredEntries, models.PreferredProject{
+				UserID:    user.ID,
+				ProjectID: project.ID,
+				GroupID:   &groupModel.GroupID,
+			})
+		}
+	}
+
+	// 4. Bulk insert preferred entries
+	if len(preferredEntries) > 0 {
+		if err := tx.Create(&preferredEntries).Error; err != nil {
+			tx.Rollback()
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to save preferred entries"})
+			return
+		}
+	}
+
+	// Commit transaction
+	if err := tx.Commit().Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to commit transaction"})
+		return
+	}
+
+	log.Printf("Preferred project updated for the Group Ids %v", groupIDs)
+	c.JSON(http.StatusCreated, gin.H{"status": "success"})
+}
+
+func (h *UserHandler) GetPreferredProject(c *gin.Context) {
+	ucookie, _ := c.Cookie(utils.CookieName)
+
+	// 1. Get the user
+	var user models.AppUser
+	if err := h.db.Where("cookie = ?", ucookie).First(&user).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "user not found"})
+		} else {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "error fetching user"})
+		}
+		return
+	}
+
+	// 2. Get preferred projects with their group and project details
+	var preferred []models.PreferredProject
+	err := h.db.Preload("Project").
+		Preload("Group").
+		Where("user_id = ?", user.ID).
+		Find(&preferred).Error
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "error fetching preferences"})
+		return
+	}
+
+	// Step 3: Group projects by group ID
+	groupMap := make(map[uint64]*GroupedProjects)
+	for _, item := range preferred {
+		if item.Group == nil {
+			continue // skip ungrouped if needed
+		}
+
+		groupID := item.Group.GroupID
+		if _, exists := groupMap[groupID]; !exists {
+			groupMap[groupID] = &GroupedProjects{
+				GroupID:   groupID,
+				GroupName: item.Group.GroupName,
+				Projects:  []ProjectSummary{},
+			}
+		}
+
+		groupMap[groupID].Projects = append(groupMap[groupID].Projects, ProjectSummary{
+			UUID: item.Project.UUID,
+			Name: item.Project.Name,
+		})
+	}
+
+	// Step 4: Convert map to slice
+	var grouped []GroupedProjects
+	for _, group := range groupMap {
+		grouped = append(grouped, *group)
+	}
+
+	// Step 5: Return response
+	response := PreferenceResponse{
+		Cookie:    user.Cookie,
+		Preferred: grouped,
+	}
+
+	c.JSON(http.StatusOK, response)
+}
+
+func (h *UserHandler) DeletePreferredProject(c *gin.Context) {
+	var req DeletePreferredRequest
+	ucookie, _ := c.Cookie(utils.CookieName)
+
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request"})
+		return
+	}
+
+	// Find user by cookie
+	var user models.AppUser
+	if err := h.db.Where("cookie = ?", ucookie).First(&user).Error; err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "user not found"})
+		return
+	}
+
+	// Collect group IDs to delete
+	var groupIDs []uint64
+	for _, pref := range req.Preferred {
+		if pref.GroupID != 0 {
+			groupIDs = append(groupIDs, pref.GroupID)
+		}
+	}
+
+	if len(groupIDs) > 0 {
+		// Begin transaction
+		tx := h.db.Begin()
+		// Delete preferred projects for the user and specified group IDs
+		if err := tx.Where("user_id = ? AND group_id IN ?", user.ID, groupIDs).
+			Delete(&models.PreferredProject{}).Error; err != nil {
+			tx.Rollback()
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to delete preferred projects"})
+			return
+		}
+
+		// Delete the project_groups
+		if err := tx.Where("user_id = ? AND group_id IN ?", user.ID, groupIDs).
+			Delete(&models.ProjectGroup{}).Error; err != nil {
+			tx.Rollback()
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to delete project group"})
+			return
+		}
+		// Commit transaction
+		if err := tx.Commit().Error; err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to commit transaction"})
+			return
+		}
+	}
+
+	log.Printf("Deleted preferred project updated for the Group Ids %v", groupIDs)
+	c.JSON(http.StatusOK, gin.H{"status": "deleted"})
+}
+
+func GetUserObject(h *UserHandler, cookie string) (models.AppUser, error) {
+	var user models.AppUser
+	if err := h.db.Where("cookie = ?", cookie).First(&user).Error; err != nil {
+		// Add entry if the user not exists
+		log.Printf("User not exists for the cookie %s, creating new user", cookie)
+		var user = models.AppUser{
+			Cookie:   cookie,
+			Timezone: "America/Los_Angeles",
+		}
+		if err := h.db.Create(&user).Error; err != nil {
+			return user, err
+		}
+		return user, nil
+	}
+	return user, nil
+}

--- a/pkg/api/handlers/user/user_preference_suite_test.go
+++ b/pkg/api/handlers/user/user_preference_suite_test.go
@@ -1,0 +1,13 @@
+package user_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestHandlers(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "User Preference Suite")
+}

--- a/pkg/api/handlers/user/user_preference_test.go
+++ b/pkg/api/handlers/user/user_preference_test.go
@@ -1,0 +1,706 @@
+package user_test
+
+import (
+	"bytes"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/gin-gonic/gin"
+	"github.com/guidewire/fern-reporter/pkg/api/handlers/user"
+	"github.com/guidewire/fern-reporter/pkg/models"
+	"github.com/guidewire/fern-reporter/pkg/utils"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+)
+
+var (
+	db     *sql.DB
+	gormDb *gorm.DB
+	mock   sqlmock.Sqlmock
+	err    error
+)
+
+var _ = BeforeEach(func() {
+	db, mock, err = sqlmock.New()
+	Expect(err).NotTo(HaveOccurred())
+
+	dialector := postgres.New(postgres.Config{
+		DSN:                  "sqlmock_db_0",
+		DriverName:           "postgres",
+		Conn:                 db,
+		PreferSimpleProtocol: true,
+	})
+	gormDb, err = gorm.Open(dialector, &gorm.Config{})
+	Expect(err).NotTo(HaveOccurred())
+})
+
+var _ = AfterEach(func() {
+	mock.ExpectClose()
+	err := db.Close()
+	if err != nil {
+		fmt.Printf("Unable to close the db connection %s", err.Error())
+	}
+})
+
+var _ = Describe("User Preference Handlers", Ordered, func() {
+	projectId := "96ad860-2a9a-504f-8861-aeafd0b2ae29"
+	ucookie := "5c0fc06d-26d9-4202-a1f3-2d024e957171"
+
+	Context("when save favourite project is invoked", func() {
+
+		var favRequest = user.FavouriteProjectRequest{
+			Favourite: projectId,
+		}
+
+		It("and save the favorite project, it should create one and return 201 OK", func() {
+			reqBody, err := json.Marshal(favRequest)
+			if err != nil {
+				fmt.Printf("Error serializing SuiteRuns: %v", err)
+				return
+			}
+
+			project_rows := sqlmock.NewRows([]string{"ID", "UUID"}).
+				AddRow(1, projectId)
+
+			user_rows := sqlmock.NewRows([]string{"ID", "Cookie"}).
+				AddRow(1, ucookie)
+
+			mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "app_users" WHERE cookie = $1 ORDER BY "app_users"."id" LIMIT $2`)).
+				WithArgs(ucookie, 1).
+				WillReturnRows(user_rows)
+
+			mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "project_details" WHERE uuid = $1 ORDER BY "project_details"."id" LIMIT $2`)).
+				WithArgs(favRequest.Favourite, 1).
+				WillReturnRows(project_rows)
+
+			mock.ExpectQuery(regexp.QuoteMeta(`SELECT count(*) FROM "preferred_projects" WHERE user_id = $1 and project_id = $2`)).
+				WithArgs(1, 1).
+				WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+
+			mock.ExpectBegin()
+			mock.ExpectQuery(regexp.QuoteMeta(`INSERT INTO "preferred_projects" ("user_id","project_id","group_id") VALUES ($1,$2,$3) RETURNING "id"`)).
+				WithArgs(1, 1, nil).
+				WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(1))
+			mock.ExpectCommit()
+
+			// Create request
+			req := httptest.NewRequest(http.MethodPost, "/user/preference", bytes.NewBuffer([]byte(reqBody)))
+			req.Header.Set("Content-Type", "application/json")
+
+			// Set the cookie on the request
+			req.AddCookie(&http.Cookie{
+				Name:  utils.CookieName,
+				Value: ucookie,
+			})
+
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Request = req
+
+			handler := user.NewUserHandler(gormDb)
+
+			handler.SaveFavouriteProject(c)
+			Expect(w.Code).To(Equal(201))
+		})
+		It("for same favorite project, it should not create one and return 201 OK", func() {
+			reqBody, err := json.Marshal(favRequest)
+			if err != nil {
+				fmt.Printf("Error serializing SuiteRuns: %v", err)
+				return
+			}
+
+			project_rows := sqlmock.NewRows([]string{"ID", "UUID"}).
+				AddRow(1, projectId)
+
+			user_rows := sqlmock.NewRows([]string{"ID", "Cookie"}).
+				AddRow(1, ucookie)
+
+			mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "app_users" WHERE cookie = $1 ORDER BY "app_users"."id" LIMIT $2`)).
+				WithArgs(ucookie, 1).
+				WillReturnRows(user_rows)
+
+			mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "project_details" WHERE uuid = $1 ORDER BY "project_details"."id" LIMIT $2`)).
+				WithArgs(favRequest.Favourite, 1).
+				WillReturnRows(project_rows)
+
+			mock.ExpectQuery(regexp.QuoteMeta(`SELECT count(*) FROM "preferred_projects" WHERE user_id = $1 and project_id = $2`)).
+				WithArgs(1, 1).
+				WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+
+			// Create request
+			req := httptest.NewRequest(http.MethodPost, "/user/preference", bytes.NewBuffer([]byte(reqBody)))
+			req.Header.Set("Content-Type", "application/json")
+
+			// Set the cookie on the request
+			req.AddCookie(&http.Cookie{
+				Name:  utils.CookieName,
+				Value: ucookie,
+			})
+
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Request = req
+
+			handler := user.NewUserHandler(gormDb)
+
+			handler.SaveFavouriteProject(c)
+			Expect(w.Code).To(Equal(201))
+		})
+		It("for invalid project, it should return Project ID not found (404)", func() {
+			reqBody, err := json.Marshal(favRequest)
+			if err != nil {
+				fmt.Printf("Error serializing SuiteRuns: %v", err)
+				return
+			}
+			user_rows := sqlmock.NewRows([]string{"ID", "Cookie"}).
+				AddRow(1, ucookie)
+
+			mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "app_users" WHERE cookie = $1 ORDER BY "app_users"."id" LIMIT $2`)).
+				WithArgs(ucookie, 1).
+				WillReturnRows(user_rows)
+
+			mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "project_details" WHERE uuid = $1 ORDER BY "project_details"."id" LIMIT $2`)).
+				WithArgs(favRequest.Favourite, 1).
+				WillReturnError(errors.New("Record not found"))
+
+			// Create request
+			req := httptest.NewRequest(http.MethodPost, "/user/preference", bytes.NewBuffer([]byte(reqBody)))
+			req.Header.Set("Content-Type", "application/json")
+
+			// Set the cookie on the request
+			req.AddCookie(&http.Cookie{
+				Name:  utils.CookieName,
+				Value: ucookie,
+			})
+
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Request = req
+
+			handler := user.NewUserHandler(gormDb)
+
+			handler.SaveFavouriteProject(c)
+			Expect(w.Code).To(Equal(404))
+		})
+	})
+	Context("when delete favourite project is invoked", func() {
+
+		It("and delete the favorite project, it should delete and return 200 OK", func() {
+			reqBody, err := json.Marshal("")
+			if err != nil {
+				fmt.Printf("Error serializing SuiteRuns: %v", err)
+				return
+			}
+
+			project_rows := sqlmock.NewRows([]string{"ID", "UUID"}).
+				AddRow(1, projectId)
+
+			user_rows := sqlmock.NewRows([]string{"ID", "Cookie"}).
+				AddRow(1, ucookie)
+
+			mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "app_users" WHERE cookie = $1 ORDER BY "app_users"."id" LIMIT $2`)).
+				WithArgs(ucookie, 1).
+				WillReturnRows(user_rows)
+
+			mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "project_details" WHERE uuid = $1 ORDER BY "project_details"."id" LIMIT $2`)).
+				WithArgs(projectId, 1).
+				WillReturnRows(project_rows)
+
+			mock.ExpectBegin()
+			mock.ExpectExec(regexp.QuoteMeta(`DELETE FROM "preferred_projects" WHERE user_id = $1 and project_id = $2`)).
+				WithArgs(1, 1).
+				WillReturnResult(sqlmock.NewResult(0, 1))
+			mock.ExpectCommit()
+			mock.ExpectClose()
+
+			// Create request
+			req := httptest.NewRequest(http.MethodDelete, "/api/user/favourite/", bytes.NewBuffer([]byte(reqBody)))
+			req.Header.Set("Content-Type", "application/json")
+
+			// Set the cookie on the request
+			req.AddCookie(&http.Cookie{
+				Name:  utils.CookieName,
+				Value: ucookie,
+			})
+
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Params = append(c.Params, gin.Param{Key: "projectUUID", Value: projectId})
+			c.Request = req
+
+			handler := user.NewUserHandler(gormDb)
+
+			handler.DeleteFavouriteProject(c)
+			Expect(w.Code).To(Equal(200))
+			Expect(w.Body.String()).To(Equal(`{"message":"Favourite Project 96ad860-2a9a-504f-8861-aeafd0b2ae29 deleted successfully"}`))
+		})
+		It("for invalid project, it should return Project ID not found (404)", func() {
+			reqBody, err := json.Marshal("")
+			if err != nil {
+				fmt.Printf("Error serializing SuiteRuns: %v", err)
+				return
+			}
+
+			user_rows := sqlmock.NewRows([]string{"ID", "Cookie"}).
+				AddRow(1, ucookie)
+
+			mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "app_users" WHERE cookie = $1 ORDER BY "app_users"."id" LIMIT $2`)).
+				WithArgs(ucookie, 1).
+				WillReturnRows(user_rows)
+
+			mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "project_details" WHERE uuid = $1 ORDER BY "project_details"."id" LIMIT $2`)).
+				WithArgs(projectId, 1).
+				WillReturnError(errors.New("Record not found"))
+
+			// Create request
+			req := httptest.NewRequest(http.MethodDelete, "/api/user/favourite/", bytes.NewBuffer([]byte(reqBody)))
+			req.Header.Set("Content-Type", "application/json")
+
+			// Set the cookie on the request
+			req.AddCookie(&http.Cookie{
+				Name:  utils.CookieName,
+				Value: ucookie,
+			})
+
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Params = append(c.Params, gin.Param{Key: "projectUUID", Value: projectId})
+			c.Request = req
+
+			handler := user.NewUserHandler(gormDb)
+
+			handler.DeleteFavouriteProject(c)
+			Expect(w.Code).To(Equal(404))
+		})
+	})
+
+	Context("when save user preference is invoked", func() {
+		var userPrefRequest = user.UserPreferenceRequest{
+			IsDark:   true,
+			Timezone: "America/New_York",
+		}
+
+		It("and save the user preference, it should save and return 202 OK", func() {
+			reqBody, err := json.Marshal(userPrefRequest)
+			if err != nil {
+				fmt.Printf("Error serializing SuiteRuns: %v", err)
+				return
+			}
+
+			user_rows := sqlmock.NewRows([]string{"ID", "Cookie"}).
+				AddRow(1, ucookie)
+
+			mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "app_users" WHERE cookie = $1 ORDER BY "app_users"."id" LIMIT $2`)).
+				WithArgs(ucookie, 1).
+				WillReturnRows(user_rows)
+
+			mock.ExpectBegin()
+			mock.ExpectExec(regexp.QuoteMeta(`UPDATE "app_users" SET "is_dark"=$1,"timezone"=$2,"updated_at"=$3 WHERE cookie = $4`)).
+				WithArgs(true, "America/New_York", sqlmock.AnyArg(), ucookie).
+				WillReturnResult(sqlmock.NewResult(0, 1))
+			mock.ExpectCommit()
+			mock.ExpectClose()
+
+			// Create request
+			req := httptest.NewRequest(http.MethodDelete, "/api/user/preference/", bytes.NewBuffer([]byte(reqBody)))
+			req.Header.Set("Content-Type", "application/json")
+
+			// Set the cookie on the request
+			req.AddCookie(&http.Cookie{
+				Name:  utils.CookieName,
+				Value: ucookie,
+			})
+
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Request = req
+
+			handler := user.NewUserHandler(gormDb)
+
+			handler.SaveUserPreference(c)
+			Expect(w.Code).To(Equal(202))
+			Expect(w.Body.String()).To(ContainSubstring("{\"status\":\"success\"}"))
+		})
+	})
+
+	Context("when get user preference is invoked", func() {
+		It("will return user preference details", func() {
+			reqBody, err := json.Marshal("")
+			if err != nil {
+				fmt.Printf("Error serializing SuiteRuns: %v", err)
+				return
+			}
+
+			user_rows := sqlmock.NewRows([]string{"ID", "IsDark", "Timezone", "Cookie"}).
+				AddRow(1, true, "America/New_York", ucookie)
+
+			mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "app_users" WHERE cookie = $1 ORDER BY "app_users"."id" LIMIT $2`)).
+				WithArgs(ucookie, 1).
+				WillReturnRows(user_rows)
+
+			// Create request
+			req := httptest.NewRequest(http.MethodDelete, "/api/user/preference", bytes.NewBuffer([]byte(reqBody)))
+			req.Header.Set("Content-Type", "application/json")
+
+			// Set the cookie on the request
+			req.AddCookie(&http.Cookie{
+				Name:  utils.CookieName,
+				Value: ucookie,
+			})
+
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Request = req
+
+			handler := user.NewUserHandler(gormDb)
+
+			handler.GetUserPreference(c)
+			var responseBody models.AppUser
+			err = json.Unmarshal(w.Body.Bytes(), &responseBody)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(w.Code).To(Equal(http.StatusOK))
+			Expect(true).To(Equal(responseBody.IsDark))
+			Expect("America/New_York").To(Equal(responseBody.Timezone))
+		})
+	})
+
+	Context("when save preferred project is invoked", func() {
+
+		prefRequest := user.PreferredRequest{
+			Preferred: []struct {
+				GroupID   uint64   `json:"group_id"`
+				GroupName string   `json:"group_name"`
+				Projects  []string `json:"projects"`
+			}{
+				{
+					GroupID:   0, // Empty group (new group creation)
+					GroupName: "First Favorite Group",
+					Projects:  []string{projectId},
+				},
+			},
+		}
+		It("with a new group and project, it should create one and return 201 OK", func() {
+			reqBody, err := json.Marshal(prefRequest)
+			if err != nil {
+				fmt.Printf("Error serializing SuiteRuns: %v", err)
+				return
+			}
+
+			user_rows := sqlmock.NewRows([]string{"ID", "IsDark", "Timezone", "Cookie"}).
+				AddRow(1, true, "America/New_York", ucookie)
+
+			//project_group_rows := sqlmock.NewRows([]string{"GroupID", "UserID", "GroupName"}).
+			//	AddRow(1, 1, "First Group")
+
+			project_rows := sqlmock.NewRows([]string{"ID", "UUID"}).
+				AddRow(1, projectId)
+
+			mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "app_users" WHERE cookie = $1 ORDER BY "app_users"."id" LIMIT $2`)).
+				WithArgs(ucookie, 1).
+				WillReturnRows(user_rows)
+
+			mock.ExpectBegin()
+			mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "project_groups" WHERE user_id = $1 AND group_id = $2 ORDER BY "project_groups"."group_id" LIMIT $3`)).
+				WithArgs(1, 0, 1).
+				WillReturnError(gorm.ErrRecordNotFound)
+
+			mock.ExpectQuery(regexp.QuoteMeta(`INSERT INTO "project_groups" ("user_id","group_name") VALUES ($1,$2) RETURNING "group_id"`)).
+				WithArgs(1, "First Favorite Group").
+				WillReturnRows(sqlmock.NewRows([]string{"group_id"}).AddRow(1))
+
+			mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "project_details" WHERE uuid = $1 ORDER BY "project_details"."id" LIMIT $2`)).
+				WithArgs(projectId, 1).
+				WillReturnRows(project_rows)
+
+			mock.ExpectQuery(regexp.QuoteMeta(`INSERT INTO "preferred_projects" ("user_id","project_id","group_id") VALUES ($1,$2,$3) RETURNING "id"`)).
+				WithArgs(1, 1, 1).
+				WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(1))
+
+			mock.ExpectCommit()
+
+			// Create request
+			req := httptest.NewRequest(http.MethodDelete, "/api/user/preference", bytes.NewBuffer([]byte(reqBody)))
+			req.Header.Set("Content-Type", "application/json")
+
+			// Set the cookie on the request
+			req.AddCookie(&http.Cookie{
+				Name:  utils.CookieName,
+				Value: ucookie,
+			})
+
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Request = req
+
+			handler := user.NewUserHandler(gormDb)
+
+			handler.SavePreferredProject(c)
+
+			Expect(w.Code).To(Equal(201))
+			Expect(w.Body.String()).To(ContainSubstring("{\"status\":\"success\"}"))
+
+		})
+		It("with an existing group and project, it should create one and return 201 OK", func() {
+
+			prefRequest := user.PreferredRequest{
+				Preferred: []struct {
+					GroupID   uint64   `json:"group_id"`
+					GroupName string   `json:"group_name"`
+					Projects  []string `json:"projects"`
+				}{
+					{
+						GroupID:   1,
+						GroupName: "First Favorite Group",
+						Projects:  []string{projectId},
+					},
+				},
+			}
+
+			reqBody, err := json.Marshal(prefRequest)
+			if err != nil {
+				fmt.Printf("Error serializing SuiteRuns: %v", err)
+				return
+			}
+
+			user_rows := sqlmock.NewRows([]string{"ID", "IsDark", "Timezone", "Cookie"}).
+				AddRow(1, true, "America/New_York", ucookie)
+
+			project_group_rows := sqlmock.NewRows([]string{"GroupID", "UserID", "GroupName"}).
+				AddRow(1, 1, "First Group")
+
+			project_rows := sqlmock.NewRows([]string{"ID", "UUID"}).
+				AddRow(1, projectId)
+
+			mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "app_users" WHERE cookie = $1 ORDER BY "app_users"."id" LIMIT $2`)).
+				WithArgs(ucookie, 1).
+				WillReturnRows(user_rows)
+
+			mock.ExpectBegin()
+
+			//DELETE FROM "preferred_projects" WHERE user_id = 1 AND group_id IN (2)
+			mock.ExpectExec(regexp.QuoteMeta(`DELETE FROM "preferred_projects" WHERE user_id = $1 AND group_id IN ($2)`)).
+				WithArgs(1, 1).
+				WillReturnResult(sqlmock.NewResult(0, 1))
+
+			mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "project_groups" WHERE user_id = $1 AND group_id = $2 ORDER BY "project_groups"."group_id" LIMIT $3`)).
+				WithArgs(1, 1, 1).
+				WillReturnRows(project_group_rows)
+
+			mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "project_details" WHERE uuid = $1 ORDER BY "project_details"."id" LIMIT $2`)).
+				WithArgs(projectId, 1).
+				WillReturnRows(project_rows)
+
+			mock.ExpectQuery(regexp.QuoteMeta(`INSERT INTO "preferred_projects" ("user_id","project_id","group_id") VALUES ($1,$2,$3) RETURNING "id"`)).
+				WithArgs(1, 1, 1).
+				WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(1))
+
+			mock.ExpectCommit()
+
+			// Create request
+			req := httptest.NewRequest(http.MethodDelete, "/api/user/preference", bytes.NewBuffer([]byte(reqBody)))
+			req.Header.Set("Content-Type", "application/json")
+
+			// Set the cookie on the request
+			req.AddCookie(&http.Cookie{
+				Name:  utils.CookieName,
+				Value: ucookie,
+			})
+
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Request = req
+
+			handler := user.NewUserHandler(gormDb)
+
+			handler.SavePreferredProject(c)
+
+			Expect(w.Code).To(Equal(201))
+			Expect(w.Body.String()).To(ContainSubstring("{\"status\":\"success\"}"))
+
+		})
+	})
+
+	Context("when get preferred project is invoked", func() {
+
+		It("will return preferred project details", func() {
+			reqBody, err := json.Marshal("")
+			if err != nil {
+				fmt.Printf("Error serializing SuiteRuns: %v", err)
+				return
+			}
+
+			user_rows := sqlmock.NewRows([]string{"ID", "IsDark", "Timezone", "Cookie"}).
+				AddRow(1, true, "America/New_York", ucookie)
+
+			project_group_rows := sqlmock.NewRows([]string{"GroupID", "UserID", "GroupName"}).
+				AddRow(1, 1, "First Group")
+
+			project_rows := sqlmock.NewRows([]string{"ID", "UUID", "Name"}).
+				AddRow(1, projectId, "First Project").
+				AddRow(2, "59e06cf8-f390-5093-af2e-3685be593a25", "Second Project")
+
+			preferred_projects := sqlmock.NewRows([]string{"ID", "UserID", "ProjectID", "GroupID"}).
+				AddRow(1, 1, 1, 1).
+				AddRow(2, 1, 2, 1)
+
+			mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "app_users" WHERE cookie = $1 ORDER BY "app_users"."id" LIMIT $2`)).
+				WithArgs(ucookie, 1).
+				WillReturnRows(user_rows)
+
+			mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "preferred_projects" WHERE user_id = $1`)).
+				WithArgs(1).
+				WillReturnRows(preferred_projects)
+
+			mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "project_groups" WHERE "project_groups"."group_id" = $1`)).
+				WithArgs(1).
+				WillReturnRows(project_group_rows)
+
+			mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "project_details" WHERE "project_details"."id" IN ($1,$2)`)).
+				WithArgs(1, 2).
+				WillReturnRows(project_rows)
+
+			// Create request
+			req := httptest.NewRequest(http.MethodDelete, "/api/user/preference", bytes.NewBuffer([]byte(reqBody)))
+			req.Header.Set("Content-Type", "application/json")
+
+			// Set the cookie on the request
+			req.AddCookie(&http.Cookie{
+				Name:  utils.CookieName,
+				Value: ucookie,
+			})
+
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Request = req
+
+			handler := user.NewUserHandler(gormDb)
+			handler.GetPreferredProject(c)
+
+			var responseBody user.PreferenceResponse
+			err = json.Unmarshal(w.Body.Bytes(), &responseBody)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(w.Code).To(Equal(http.StatusOK))
+			Expect(responseBody.Preferred).To(Not(Equal(0)))
+			Expect(responseBody.Preferred[0].GroupName).To(Equal("First Group"))
+			Expect(len(responseBody.Preferred[0].Projects)).To(Equal(2))
+			Expect(responseBody.Preferred[0].Projects[0].UUID).To(Equal("96ad860-2a9a-504f-8861-aeafd0b2ae29"))
+		})
+		It("for empty preferred project details, will return empty object", func() {
+			reqBody, err := json.Marshal("")
+			if err != nil {
+				fmt.Printf("Error serializing SuiteRuns: %v", err)
+				return
+			}
+
+			user_rows := sqlmock.NewRows([]string{"ID", "IsDark", "Timezone", "Cookie"}).
+				AddRow(1, true, "America/New_York", ucookie)
+
+			project_rows := sqlmock.NewRows([]string{"ID", "UUID", "Name"}).
+				AddRow(1, projectId, "First Project").
+				AddRow(2, "59e06cf8-f390-5093-af2e-3685be593a25", "Second Project")
+
+			preferred_projects := sqlmock.NewRows([]string{"ID", "UserID", "ProjectID", "GroupID"}) //empty rows
+
+			mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "app_users" WHERE cookie = $1 ORDER BY "app_users"."id" LIMIT $2`)).
+				WithArgs(ucookie, 1).
+				WillReturnRows(user_rows)
+
+			mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "preferred_projects" WHERE user_id = $1`)).
+				WithArgs(1).
+				WillReturnRows(preferred_projects)
+
+			mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "project_details" WHERE "project_details"."id" IN ($1,$2)`)).
+				WithArgs(1, 2).
+				WillReturnRows(project_rows)
+
+			// Create request
+			req := httptest.NewRequest(http.MethodDelete, "/api/user/preference", bytes.NewBuffer([]byte(reqBody)))
+			req.Header.Set("Content-Type", "application/json")
+
+			// Set the cookie on the request
+			req.AddCookie(&http.Cookie{
+				Name:  utils.CookieName,
+				Value: ucookie,
+			})
+
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Request = req
+
+			handler := user.NewUserHandler(gormDb)
+			handler.GetPreferredProject(c)
+
+			var responseBody user.PreferenceResponse
+			err = json.Unmarshal(w.Body.Bytes(), &responseBody)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(w.Code).To(Equal(http.StatusOK))
+			Expect(responseBody.Preferred).To(BeNil())
+		})
+	})
+
+	Context("when delete preferred project is invoked", func() {
+
+		delPrefRequest := user.DeletePreferredRequest{
+			Preferred: []struct {
+				GroupID uint64 `json:"group_id"`
+			}{{
+				GroupID: 1,
+			}},
+		}
+
+		It("will delete preferred project", func() {
+			reqBody, err := json.Marshal(delPrefRequest)
+			if err != nil {
+				fmt.Printf("Error serializing SuiteRuns: %v", err)
+				return
+			}
+
+			user_rows := sqlmock.NewRows([]string{"ID", "IsDark", "Timezone", "Cookie"}).
+				AddRow(1, true, "America/New_York", ucookie)
+
+			mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "app_users" WHERE cookie = $1 ORDER BY "app_users"."id" LIMIT $2`)).
+				WithArgs(ucookie, 1).
+				WillReturnRows(user_rows)
+
+			mock.ExpectBegin()
+			mock.ExpectExec(regexp.QuoteMeta(`DELETE FROM "preferred_projects" WHERE user_id = $1 AND group_id IN ($2)`)).
+				WithArgs(1, 1).
+				WillReturnResult(sqlmock.NewResult(0, 1))
+
+			mock.ExpectExec(regexp.QuoteMeta(`DELETE FROM "project_groups" WHERE user_id = $1 AND group_id IN ($2)`)).
+				WithArgs(1, 1).
+				WillReturnResult(sqlmock.NewResult(0, 1))
+			mock.ExpectCommit()
+
+			// Create request
+			req := httptest.NewRequest(http.MethodDelete, "/api/user/preference", bytes.NewBuffer([]byte(reqBody)))
+			req.Header.Set("Content-Type", "application/json")
+
+			// Set the cookie on the request
+			req.AddCookie(&http.Cookie{
+				Name:  utils.CookieName,
+				Value: ucookie,
+			})
+
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Request = req
+
+			handler := user.NewUserHandler(gormDb)
+			handler.DeletePreferredProject(c)
+
+			Expect(w.Code).To(Equal(200))
+			Expect(w.Body.String()).To(ContainSubstring("{\"status\":\"deleted\"}"))
+		})
+	})
+})

--- a/pkg/api/routers/routers_test.go
+++ b/pkg/api/routers/routers_test.go
@@ -3,6 +3,7 @@ package routers_test
 import (
 	"database/sql"
 	"fmt"
+	"github.com/guidewire/fern-reporter/pkg/api/handlers/project"
 	"os"
 	"reflect"
 	"runtime"
@@ -11,6 +12,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/guidewire/fern-reporter/config"
 	"github.com/guidewire/fern-reporter/pkg/api/handlers"
+	"github.com/guidewire/fern-reporter/pkg/api/handlers/user"
 	"github.com/guidewire/fern-reporter/pkg/api/routers"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -48,6 +50,8 @@ var _ = Describe("RegisterRouters", func() {
 	Context("Registering routes", func() {
 		It("should register API routes", func() {
 			handler := handlers.NewHandler(gormDb)
+			userHandler := user.NewUserHandler(gormDb)
+			projectHandler := project.NewProjectHandler(gormDb)
 
 			routers.RegisterRouters(router)
 
@@ -59,6 +63,19 @@ var _ = Describe("RegisterRouters", func() {
 			ExpectRoute(router, "POST", "/api/testrun/", handler.CreateTestRun)
 			ExpectRoute(router, "PUT", "/api/testrun/:id", handler.UpdateTestRun)
 			ExpectRoute(router, "DELETE", "/api/testrun/:id", handler.DeleteTestRun)
+
+			ExpectRoute(router, "GET", "/api/project", projectHandler.GetAllProjects)
+			ExpectRoute(router, "POST", "/api/project", projectHandler.CreateProject)
+			ExpectRoute(router, "PUT", "/api/project/:uuid", projectHandler.UpdateProject)
+			ExpectRoute(router, "DELETE", "/api/project/:uuid", projectHandler.DeleteProject)
+
+			ExpectRoute(router, "POST", "/api/user/favourite", userHandler.SaveFavouriteProject)
+			ExpectRoute(router, "DELETE", "/api/user/favourite/:projectUUID", userHandler.DeleteFavouriteProject)
+			ExpectRoute(router, "PUT", "/api/user/preference", userHandler.SaveUserPreference)
+			ExpectRoute(router, "GET", "/api/user/preference", userHandler.GetUserPreference)
+			ExpectRoute(router, "POST", "/api/user/preferred", userHandler.SavePreferredProject)
+			ExpectRoute(router, "GET", "/api/user/preferred", userHandler.GetPreferredProject)
+			ExpectRoute(router, "DELETE", "/api/user/preferred", userHandler.DeletePreferredProject)
 		})
 
 		It("should register report routes", func() {

--- a/pkg/db/migrations/000008_create_user_project_groups_preferred_projects_table.down.sql
+++ b/pkg/db/migrations/000008_create_user_project_groups_preferred_projects_table.down.sql
@@ -1,0 +1,10 @@
+-- Drop indexes first
+DROP INDEX IF EXISTS idx_user_project_group;
+DROP INDEX IF EXISTS idx_app_user_cookie;
+DROP INDEX IF EXISTS idx_user_id_group_id;
+DROP INDEX IF EXISTS idx_user_id;
+
+-- Drop tables in reverse dependency order
+DROP TABLE IF EXISTS preferred_projects;
+DROP TABLE IF EXISTS project_groups;
+DROP TABLE IF EXISTS app_users;

--- a/pkg/db/migrations/000008_create_user_project_groups_preferred_projects_table.up.sql
+++ b/pkg/db/migrations/000008_create_user_project_groups_preferred_projects_table.up.sql
@@ -1,0 +1,41 @@
+-- App User Table
+CREATE TABLE app_users
+(
+    id         SERIAL PRIMARY KEY,
+    is_dark    BOOLEAN   DEFAULT false,
+    timezone   VARCHAR(40),
+    cookie     VARCHAR(40),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+
+);
+
+-- User Project Groups Table
+CREATE TABLE project_groups
+(
+    group_id   SERIAL PRIMARY KEY,
+    user_id    INT          NOT NULL,
+    group_name VARCHAR(255) NOT NULL,
+    CONSTRAINT unique_group_per_user UNIQUE (user_id, group_name),
+    CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES app_users (id) ON DELETE CASCADE
+);
+
+-- User Preferred Projects Table
+CREATE TABLE preferred_projects
+(
+    id         SERIAL PRIMARY KEY,
+    user_id    INT NOT NULL,
+    project_id INT NOT NULL, -- References project_details.project_id
+    group_id   INT,          -- References user_project_groups.group_id (NULL for ungrouped)
+    CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES app_users (id) ON DELETE CASCADE,
+    CONSTRAINT fk_project FOREIGN KEY (project_id) REFERENCES project_details (id) ON DELETE CASCADE,
+    CONSTRAINT fk_group FOREIGN KEY (group_id) REFERENCES project_groups (group_id) ON DELETE SET NULL
+);
+
+-- Index
+CREATE UNIQUE INDEX idx_user_project_group ON preferred_projects (user_id, project_id, group_id);
+
+CREATE INDEX idx_app_user_cookie ON app_users (cookie);
+
+CREATE INDEX idx_user_id_group_id ON project_groups (user_id, group_id);
+CREATE INDEX idx_user_id ON project_groups (user_id);

--- a/pkg/models/types.go
+++ b/pkg/models/types.go
@@ -77,5 +77,31 @@ type ProjectDetails struct {
 	TeamName  string    `json:"team_name"`
 	Comment   string    `json:"comment"`
 	CreatedAt time.Time `json:"created_at" gorm:"default:CURRENT_TIMESTAMP"`
-	UpdatedAt time.Time `json:"updated_at"`
+	UpdatedAt time.Time `json:"updated_at" gorm:"autoUpdateTime"`
+}
+
+type PreferredProject struct {
+	ID        uint64 `gorm:"primaryKey;autoIncrement"`
+	UserID    uint64
+	ProjectID uint64
+	GroupID   *uint64 // Nullable field (for ungrouped)
+
+	User    AppUser        `gorm:"foreignKey:ID;constraint:OnDelete:CASCADE"`
+	Project ProjectDetails `gorm:"foreignKey:ProjectID;references:ID;constraint:OnDelete:CASCADE"`
+	Group   *ProjectGroup  `gorm:"foreignKey:GroupID;references:GroupID;constraint:OnDelete:SET NULL"`
+}
+
+type ProjectGroup struct {
+	GroupID   uint64 `gorm:"primaryKey;autoIncrement;column:group_id"`
+	UserID    uint64
+	GroupName string
+}
+
+type AppUser struct {
+	ID        uint64    `gorm:"primaryKey"`
+	IsDark    bool      `gorm:"column:is_dark;default:false"`
+	Timezone  string    `gorm:"size:40"`
+	Cookie    string    `gorm:"size:40;index:idx_app_user_cookie"`
+	CreatedAt time.Time `gorm:"autoCreateTime"` // set once when created
+	UpdatedAt time.Time `gorm:"autoUpdateTime"` // updated automatically on update
 }

--- a/pkg/utils/constants.go
+++ b/pkg/utils/constants.go
@@ -1,0 +1,5 @@
+package utils
+
+const (
+	CookieName = "fern_user_cookie"
+)

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -3,6 +3,8 @@ package utils
 import (
 	"encoding/base64"
 	"fmt"
+	"github.com/gin-gonic/gin"
+	"net/http"
 	"time"
 
 	"github.com/guidewire/fern-reporter/pkg/models"
@@ -14,6 +16,31 @@ const (
 	StatusPassed     = "passed"
 	StatusFailed     = "failed"
 )
+
+type ApiResponse[T any] struct {
+	Success bool   `json:"success"`
+	Message string `json:"message"`
+	Data    *T     `json:"data,omitempty"`  // Pointer so it's omitted if nil
+	Error   string `json:"error,omitempty"` // Only used on failure
+}
+
+func Success[T any](c *gin.Context, message string, data *T) *gin.Context {
+	c.JSON(http.StatusOK, ApiResponse[T]{
+		Success: true,
+		Message: message,
+		Data:    data,
+	})
+	return c
+}
+
+func Error[T any](c *gin.Context, statusCode int, message string, err string) *gin.Context {
+	c.JSON(statusCode, ApiResponse[T]{
+		Success: false,
+		Message: message,
+		Error:   err,
+	})
+	return c
+}
 
 func CalculateDuration(start, end time.Time) string {
 	duration := end.Sub(start)


### PR DESCRIPTION
Refer to this https://github.com/guidewire-oss/fern-reporter/issues/237 for Table and API details.
    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Added new APIs to store and retrieve user favourite projects and project preferences, including support for grouping preferred projects and saving user settings.

- **New Features**
  - Added endpoints to save, get, and delete favourite projects for a user.
  - Added endpoints to save, get, and delete grouped preferred projects.
  - Added endpoints to save and retrieve user preferences like dark mode and timezone.
  - Created new database tables and migrations for user preferences, groups, and favourites.

<!-- End of auto-generated description by mrge. -->

