### PR TITLE
Fix(ci): Remove unused 32 bit arch

### DIFF
--- a/.github/workflows/build-server.yml
+++ b/.github/workflows/build-server.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     tags:
-      - 'v*.*.*'
+      - "v*.*.*"
 
 jobs:
   build-and-push:
@@ -30,5 +30,4 @@ jobs:
           file: ./Dockerfile
           push: true
           tags: anoop2811/fern-reporter:latest
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
-
+          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
- GORM fails on 32 bit while building
    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Removed 32-bit build target from CI to fix GORM build failures and simplify supported architectures.

<!-- End of auto-generated description by mrge. -->

