### PR TITLE
Feat: Addition of GET endpoint to fetch user's favourite project UUIDs

### DIFF
--- a/pkg/api/routers/routers.go
+++ b/pkg/api/routers/routers.go
@@ -55,6 +55,7 @@ func RegisterRouters(router *gin.Engine) {
 		user := api.Group("/user")
 		user.POST("/favourite", userHandler.SaveFavouriteProject)
 		user.DELETE("/favourite/:projectUUID", userHandler.DeleteFavouriteProject)
+		user.GET("/favourite", userHandler.GetFavouriteProject)
 		user.PUT("/preference", userHandler.SaveUserPreference)
 		user.GET("/preference", userHandler.GetUserPreference)
 		user.POST("/preferred", userHandler.SavePreferredProject)

--- a/pkg/api/routers/routers_test.go
+++ b/pkg/api/routers/routers_test.go
@@ -71,6 +71,7 @@ var _ = Describe("RegisterRouters", func() {
 
 			ExpectRoute(router, "POST", "/api/user/favourite", userHandler.SaveFavouriteProject)
 			ExpectRoute(router, "DELETE", "/api/user/favourite/:projectUUID", userHandler.DeleteFavouriteProject)
+			ExpectRoute(router, "GET", "/api/user/favourite", userHandler.GetFavouriteProject)
 			ExpectRoute(router, "PUT", "/api/user/preference", userHandler.SaveUserPreference)
 			ExpectRoute(router, "GET", "/api/user/preference", userHandler.GetUserPreference)
 			ExpectRoute(router, "POST", "/api/user/preferred", userHandler.SavePreferredProject)


### PR DESCRIPTION
Implements #262 

- Added GET `/api/user/favourite` to fetch the list of favourite project
- Returns a list of UUID's of the user's favourite project
- Handles cases where the user is not found, and DB error scenario
    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Added a GET /api/user/favourite endpoint to fetch a user's favourite project UUIDs.

- **New Features**
  - Returns a list of favourite project UUIDs for the authenticated user.
  - Handles user not found and database error cases with clear error responses.

<!-- End of auto-generated description by mrge. -->

