### PR TITLE
feat: Add tags and project information in testruns API

### DIFF
--- a/pkg/api/handlers/handlers.go
+++ b/pkg/api/handlers/handlers.go
@@ -173,7 +173,7 @@ func (h *Handler) DeleteTestRun(c *gin.Context) {
 
 func (h *Handler) ReportTestRunAll(c *gin.Context) {
 	var testRuns []models.TestRun
-	h.db.Preload("SuiteRuns.SpecRuns.Tags").Find(&testRuns)
+	h.db.Preload("SuiteRuns.SpecRuns.Tags").Preload("Project").Find(&testRuns)
 
 	c.JSON(http.StatusOK, gin.H{
 		"testRuns":     testRuns,
@@ -185,7 +185,7 @@ func (h *Handler) ReportTestRunAll(c *gin.Context) {
 func (h *Handler) ReportTestRunById(c *gin.Context) {
 	var testRun models.TestRun
 	id := c.Param("id")
-	h.db.Preload("SuiteRuns.SpecRuns").Where("id = ?", id).First(&testRun)
+	h.db.Preload("SuiteRuns.SpecRuns.Tags").Preload("Project").Where("id = ?", id).First(&testRun)
 
 	c.JSON(http.StatusOK, gin.H{
 		"reportHeader": config.GetHeaderName(),


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
The testruns API now includes tags and project information in its responses for both all test runs and individual test run reports. This makes it easier to access related metadata when fetching test run data.

<!-- End of auto-generated description by cubic. -->

