### PR TITLE
feat: Add tags and project information in testruns API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ go.work
 bin/
 
 .git-authors
+
+# Test coverage files
+profile.cov

--- a/pkg/api/handlers/handler_utils_test.go
+++ b/pkg/api/handlers/handler_utils_test.go
@@ -1,6 +1,7 @@
 package handlers_test
 
 import (
+	"database/sql"
 	"fmt"
 	"html/template"
 	"net/http"
@@ -21,26 +22,32 @@ import (
 	"gorm.io/gorm"
 )
 
-var _ = BeforeEach(func() {
-	db, mock, _ = sqlmock.New()
-
-	dialector := postgres.New(postgres.Config{
-		DSN:                  "sqlmock_db_0",
-		DriverName:           "postgres",
-		Conn:                 db,
-		PreferSimpleProtocol: true,
-	})
-	gormDb, _ = gorm.Open(dialector, &gorm.Config{})
-})
-
-var _ = AfterEach(func() {
-	err := db.Close()
-	if err != nil {
-		fmt.Printf("Unable to close the db connection %s", err.Error())
-	}
-})
-
 var _ = Describe("Insights test", func() {
+	var (
+		db     *sql.DB
+		gormDb *gorm.DB
+		mock   sqlmock.Sqlmock
+	)
+
+	var _ = BeforeEach(func() {
+		db, mock, _ = sqlmock.New()
+
+		dialector := postgres.New(postgres.Config{
+			DSN:                  "sqlmock_db_0",
+			DriverName:           "postgres",
+			Conn:                 db,
+			PreferSimpleProtocol: true,
+		})
+		gormDb, _ = gorm.Open(dialector, &gorm.Config{})
+	})
+
+	var _ = AfterEach(func() {
+		err := db.Close()
+		if err != nil {
+			fmt.Printf("Unable to close the db connection %s", err.Error())
+		}
+	})
+
 	Context("When ReportTestInsights is invoked", func() {
 		gin.SetMode(gin.TestMode)
 		router := gin.Default()

--- a/pkg/api/handlers/handlers.go
+++ b/pkg/api/handlers/handlers.go
@@ -117,14 +117,14 @@ func ProcessTags(db *gorm.DB, testRun *models.TestRun) error {
 
 func (h *Handler) GetTestRunAll(c *gin.Context) {
 	var testRuns []models.TestRun
-	h.db.Find(&testRuns)
+	h.db.Preload("Project").Find(&testRuns)
 	c.JSON(http.StatusOK, testRuns)
 }
 
 func (h *Handler) GetTestRunByID(c *gin.Context) {
 	var testRun models.TestRun
 	id := c.Param("id")
-	h.db.Where("id = ?", id).First(&testRun)
+	h.db.Preload("Project").Where("id = ?", id).First(&testRun)
 	c.JSON(http.StatusOK, testRun)
 
 }
@@ -173,7 +173,7 @@ func (h *Handler) DeleteTestRun(c *gin.Context) {
 
 func (h *Handler) ReportTestRunAll(c *gin.Context) {
 	var testRuns []models.TestRun
-	h.db.Preload("SuiteRuns.SpecRuns.Tags").Find(&testRuns)
+	h.db.Preload("SuiteRuns.SpecRuns.Tags").Preload("Project").Find(&testRuns)
 
 	c.JSON(http.StatusOK, gin.H{
 		"testRuns":     testRuns,
@@ -185,7 +185,7 @@ func (h *Handler) ReportTestRunAll(c *gin.Context) {
 func (h *Handler) ReportTestRunById(c *gin.Context) {
 	var testRun models.TestRun
 	id := c.Param("id")
-	h.db.Preload("SuiteRuns.SpecRuns").Where("id = ?", id).First(&testRun)
+	h.db.Preload("SuiteRuns.SpecRuns.Tags").Preload("Project").Where("id = ?", id).First(&testRun)
 
 	c.JSON(http.StatusOK, gin.H{
 		"reportHeader": config.GetHeaderName(),

--- a/pkg/api/handlers/handlers_test.go
+++ b/pkg/api/handlers/handlers_test.go
@@ -23,32 +23,32 @@ import (
 	"github.com/guidewire/fern-reporter/pkg/models"
 )
 
-var (
-	db     *sql.DB
-	gormDb *gorm.DB
-	mock   sqlmock.Sqlmock
-)
-
-var _ = BeforeEach(func() {
-	db, mock, _ = sqlmock.New()
-
-	dialector := postgres.New(postgres.Config{
-		DSN:                  "sqlmock_db_0",
-		DriverName:           "postgres",
-		Conn:                 db,
-		PreferSimpleProtocol: true,
-	})
-	gormDb, _ = gorm.Open(dialector, &gorm.Config{})
-})
-
-var _ = AfterEach(func() {
-	err := db.Close()
-	if err != nil {
-		fmt.Printf("Unable to close the db connection %s", err.Error())
-	}
-})
-
 var _ = Describe("Handlers", func() {
+	var (
+		db     *sql.DB
+		gormDb *gorm.DB
+		mock   sqlmock.Sqlmock
+	)
+
+	var _ = BeforeEach(func() {
+		db, mock, _ = sqlmock.New()
+
+		dialector := postgres.New(postgres.Config{
+			DSN:                  "sqlmock_db_0",
+			DriverName:           "postgres",
+			Conn:                 db,
+			PreferSimpleProtocol: true,
+		})
+		gormDb, _ = gorm.Open(dialector, &gorm.Config{})
+	})
+
+	var _ = AfterEach(func() {
+		err := db.Close()
+		if err != nil {
+			fmt.Printf("Unable to close the db connection %s", err.Error())
+		}
+	})
+
 	Context("when GetTestRunAll handler is invoked", func() {
 		It("should query db to fetch all records", func() {
 			rows := sqlmock.NewRows([]string{"ID", "TestProjectName"}).

--- a/pkg/api/handlers/report_testrun_handlers_test.go
+++ b/pkg/api/handlers/report_testrun_handlers_test.go
@@ -1,0 +1,162 @@
+package handlers_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/guidewire/fern-reporter/pkg/api/handlers"
+	"github.com/guidewire/fern-reporter/pkg/models"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+var _ = Describe("ReportTestRunAll Handler", func() {
+	var (
+		router *gin.Engine
+		db     *gorm.DB
+	)
+
+	BeforeEach(func() {
+		gin.SetMode(gin.TestMode)
+
+		db, _ = gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+		Expect(db.AutoMigrate(&models.TestRun{}, &models.ProjectDetails{}, &models.SuiteRun{}, &models.SpecRun{}, &models.Tag{})).To(Succeed())
+
+		handler := handlers.NewHandler(db)
+
+		// Seed Project
+		project := models.ProjectDetails{
+			Name:     "Demo Project",
+			TeamName: "QA",
+			Comment:  "Seed project",
+		}
+		Expect(db.Create(&project).Error).NotTo(HaveOccurred(), "failed to create seed project")
+
+		// Seed TestRun
+		testRun := models.TestRun{
+			TestSeed:  5678,
+			GitBranch: "main",
+			GitSha:    "abc123",
+			ProjectID: project.ID,
+			StartTime: time.Now(),
+			EndTime:   time.Now(),
+		}
+		Expect(db.Create(&testRun).Error).NotTo(HaveOccurred(), "failed to create test run")
+
+		// Seed SuiteRun
+		suite := models.SuiteRun{
+			TestRunID: testRun.ID,
+			SuiteName: "Suite A",
+			StartTime: time.Now(),
+			EndTime:   time.Now(),
+		}
+		Expect(db.Create(&suite).Error).NotTo(HaveOccurred(), "failed to create suite")
+		// Seed SpecRun
+		spec := models.SpecRun{
+			SuiteID:         suite.ID,
+			SpecDescription: "should pass",
+			Status:          "passed",
+			StartTime:       time.Now(),
+			EndTime:         time.Now(),
+		}
+		Expect(db.Create(&spec).Error).NotTo(HaveOccurred(), "failed to create spec")
+
+		// Seed Tag
+		tag := models.Tag{Name: "env"}
+		Expect(db.Create(&tag).Error).NotTo(HaveOccurred())
+
+		err := db.Model(&spec).Association("Tags").Append(&tag)
+		Expect(err).NotTo(HaveOccurred(), "failed to associate tag with specrun")
+
+		// Router
+		router = gin.Default()
+		api := router.Group("/api")
+		report := api.Group("/reports")
+		report.GET("/testruns/", handler.ReportTestRunAll)
+	})
+
+	It("should return a test run with project and tags", func() {
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/reports/testruns/", nil)
+
+		router.ServeHTTP(w, req)
+		Expect(w.Code).To(Equal(http.StatusOK))
+
+		var response struct {
+			TestRuns     []map[string]interface{} `json:"testRuns"`
+			ReportHeader string                   `json:"reportHeader"`
+			Total        int                      `json:"total"`
+		}
+		Expect(json.Unmarshal(w.Body.Bytes(), &response)).To(Succeed())
+
+		Expect(response.Total).To(Equal(1))
+		Expect(response.TestRuns).To(HaveLen(1))
+
+		run := response.TestRuns[0]
+		Expect(run).To(HaveKey("project"))
+		project := run["project"].(map[string]interface{})
+		Expect(project["name"]).To(Equal("Demo Project"))
+
+		Expect(run).To(HaveKey("suite_runs"))
+		suites := run["suite_runs"].([]interface{})
+		Expect(suites).ToNot(BeEmpty())
+
+		specRuns := suites[0].(map[string]interface{})["spec_runs"].([]interface{})
+		Expect(specRuns).ToNot(BeEmpty())
+
+		spec := specRuns[0].(map[string]interface{})
+		Expect(spec).To(HaveKey("tags"))
+
+		tags := spec["tags"].([]interface{})
+		Expect(tags).ToNot(BeEmpty())
+		Expect(tags[0].(map[string]interface{})["name"]).To(Equal("env"))
+	})
+
+	It("should return test run by ID with project and tags", func() {
+		// Create a fresh recorder and request for /:id
+		var testRun models.TestRun
+		db.First(&testRun) // get the ID we created in BeforeEach
+
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/reports/testruns/"+fmt.Sprint(testRun.ID)+"/", nil)
+
+		// Add route to router
+		router.GET("/api/reports/testruns/:id/", handlers.NewHandler(db).ReportTestRunById)
+
+		router.ServeHTTP(w, req)
+		Expect(w.Code).To(Equal(http.StatusOK))
+
+		var response struct {
+			TestRuns     []map[string]interface{} `json:"testRuns"`
+			ReportHeader string                   `json:"reportHeader"`
+		}
+		Expect(json.Unmarshal(w.Body.Bytes(), &response)).To(Succeed())
+		Expect(response.TestRuns).To(HaveLen(1))
+
+		run := response.TestRuns[0]
+		Expect(run).To(HaveKey("project"))
+		project := run["project"].(map[string]interface{})
+		Expect(project["name"]).To(Equal("Demo Project"))
+
+		Expect(run).To(HaveKey("suite_runs"))
+		suites := run["suite_runs"].([]interface{})
+		Expect(suites).ToNot(BeEmpty())
+
+		specRuns := suites[0].(map[string]interface{})["spec_runs"].([]interface{})
+		Expect(specRuns).ToNot(BeEmpty())
+
+		spec := specRuns[0].(map[string]interface{})
+		Expect(spec).To(HaveKey("tags"))
+
+		tags := spec["tags"].([]interface{})
+		Expect(tags).ToNot(BeEmpty())
+		Expect(tags[0].(map[string]interface{})["name"]).To(Equal("env"))
+	})
+
+})

--- a/pkg/api/handlers/testrun_handlers_test.go
+++ b/pkg/api/handlers/testrun_handlers_test.go
@@ -1,0 +1,100 @@
+package handlers_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/guidewire/fern-reporter/pkg/api/handlers"
+	"github.com/guidewire/fern-reporter/pkg/models"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+var _ = Describe("TestRun Handler JSON Response", func() {
+	var (
+		router  *gin.Engine
+		db      *gorm.DB
+		testRun models.TestRun
+		project models.ProjectDetails
+	)
+
+	BeforeEach(func() {
+		gin.SetMode(gin.TestMode)
+		db, _ = gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+		_ = db.AutoMigrate(&models.TestRun{}, &models.ProjectDetails{})
+
+		handler := handlers.NewHandler(db)
+
+		// Seed DB
+		project = models.ProjectDetails{
+			Name:     "Demo Project",
+			TeamName: "Test Team",
+			Comment:  "Some notes",
+		}
+		db.Create(&project)
+
+		testRun = models.TestRun{
+			TestSeed:  1234,
+			GitBranch: "main",
+			GitSha:    "abc123",
+			ProjectID: project.ID,
+			StartTime: time.Now(),
+			EndTime:   time.Now(),
+		}
+		db.Create(&testRun)
+
+		router = gin.Default()
+		api := router.Group("/api")
+		testRunGroup := api.Group("/testrun")
+		testRunGroup.GET("/", handler.GetTestRunAll)
+		testRunGroup.GET("/:id", handler.GetTestRunByID) // <- add this
+	})
+
+	It("should return test run with lowercase `project`", func() {
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/testrun/", nil)
+
+		router.ServeHTTP(w, req)
+
+		Expect(w.Code).To(Equal(http.StatusOK))
+
+		var parsed []map[string]interface{}
+		Expect(json.Unmarshal(w.Body.Bytes(), &parsed)).To(Succeed())
+		Expect(parsed).To(HaveLen(1))
+
+		run := parsed[0]
+
+		Expect(run).To(HaveKey("project"))
+		project := run["project"].(map[string]interface{})
+		Expect(project["name"]).To(Equal("Demo Project"))
+		Expect(project["team_name"]).To(Equal("Test Team"))
+
+		Expect(run).ToNot(HaveKey("tags"), "Expected 'tags' to be absent from the response")
+	})
+
+	It("should return a single test run by ID with project", func() {
+		url := fmt.Sprintf("/api/testrun/%d", testRun.ID)
+		req, _ := http.NewRequest("GET", url, nil)
+		w := httptest.NewRecorder()
+
+		router.ServeHTTP(w, req)
+
+		Expect(w.Code).To(Equal(http.StatusOK))
+
+		var run map[string]interface{}
+		Expect(json.Unmarshal(w.Body.Bytes(), &run)).To(Succeed())
+
+		Expect(run).To(HaveKey("project"))
+		project := run["project"].(map[string]interface{})
+		Expect(project["name"]).To(Equal("Demo Project"))
+		Expect(project["team_name"]).To(Equal("Test Team"))
+
+		Expect(run).ToNot(HaveKey("tags"), "Expected 'tags' to be absent from the response")
+	})
+})

--- a/pkg/api/routers/routers.go
+++ b/pkg/api/routers/routers.go
@@ -15,7 +15,18 @@ var (
 	testRun *gin.RouterGroup
 )
 
+func NoCacheMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Header("Cache-Control", "no-store, no-cache, must-revalidate, proxy-revalidate")
+		c.Header("Pragma", "no-cache")
+		c.Header("Expires", "0")
+		c.Header("Surrogate-Control", "no-store")
+		c.Next()
+	}
+}
+
 func RegisterRouters(router *gin.Engine) {
+	router.Use(NoCacheMiddleware())
 	handler := handlers.NewHandler(db.GetDb())
 	userHandler := user.NewUserHandler(db.GetDb())
 	projectHandler := project.NewProjectHandler(db.GetDb())

--- a/pkg/models/types.go
+++ b/pkg/models/types.go
@@ -24,7 +24,7 @@ type TestRun struct {
 	SuiteRuns         []SuiteRun `json:"suite_runs" gorm:"foreignKey:TestRunID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE"`
 
 	// Relationship with ProjectDetails
-	Project ProjectDetails `gorm:"foreignKey:ProjectID;references:ID"`
+	Project ProjectDetails `json:"project" gorm:"foreignKey:ProjectID;references:ID"`
 }
 
 type SuiteRun struct {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added tags and project details to the testruns API responses so clients can access this information directly.

- **New Features**
  - testruns API endpoints now include related tags and project data in their JSON responses.

<!-- End of auto-generated description by cubic. -->

