### PR TITLE
Feat: Add filters to reports testruns api and add tests

### DIFF
--- a/pkg/api/routers/routers.go
+++ b/pkg/api/routers/routers.go
@@ -53,6 +53,7 @@ func RegisterRouters(router *gin.Engine) {
 		testReport.GET("/projects/", projectHandler.GetAllProjectsForReport)
 		testReport.GET("/summary/:projectId/", handler.GetTestSummary)
 		testReport.GET("/testruns/", handler.ReportTestRunAll)
+		testReport.GET("/testruns", handler.ReportTestRunAll)
 		testReport.GET("/testruns/:id/", handler.ReportTestRunById)
 
 		// Project

--- a/pkg/models/types.go
+++ b/pkg/models/types.go
@@ -105,3 +105,12 @@ type AppUser struct {
 	CreatedAt time.Time `gorm:"autoCreateTime"` // set once when created
 	UpdatedAt time.Time `gorm:"autoUpdateTime"` // updated automatically on update
 }
+
+type TestQueryFilter struct {
+	ProjectID string
+	GitBranch string
+	GitSha    string
+	StartTime *time.Time
+	EndTime   *time.Time
+	Tags      []string
+}


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added filtering to the /reports/testruns API so users can filter test runs by project, branch, SHA, date, and tags. Added tests to cover the new filter options.

- **New Features**
  - Support for filtering test runs by project_id, git_branch, git_sha, start_time, end_time, and tags in the API.
  - Added tests for all filter combinations.

<!-- End of auto-generated description by cubic. -->

