### PR TITLE
Feat: add tag category - #305

### DIFF
--- a/pkg/db/migrations/000010_alter_tags_table.down.sql
+++ b/pkg/db/migrations/000010_alter_tags_table.down.sql
@@ -1,0 +1,10 @@
+-- Drop indexes
+DROP INDEX IF EXISTS idx_suite_run_tags_tag_id;
+DROP INDEX IF EXISTS idx_spec_run_tags_tag_id;
+DROP INDEX IF EXISTS idx_tags_category_value;
+DROP INDEX IF EXISTS idx_tags_category;
+
+-- Drop columns from tags table
+ALTER TABLE public.tags
+DROP COLUMN IF EXISTS category,
+DROP COLUMN IF EXISTS value;

--- a/pkg/db/migrations/000010_alter_tags_table.up.sql
+++ b/pkg/db/migrations/000010_alter_tags_table.up.sql
@@ -1,0 +1,8 @@
+ALTER TABLE public.tags
+ADD COLUMN category TEXT,
+ADD COLUMN value TEXT;
+
+CREATE INDEX idx_tags_category ON tags (category);
+CREATE INDEX idx_tags_category_value ON tags (category, value);
+CREATE INDEX idx_spec_run_tags_tag_id ON spec_run_tags (tag_id);
+CREATE INDEX idx_suite_run_tags_tag_id ON suite_run_tags (tag_id);

--- a/pkg/models/types.go
+++ b/pkg/models/types.go
@@ -67,8 +67,10 @@ type TestSummary struct {
 }
 
 type Tag struct {
-	ID   uint64 `json:"id" gorm:"primaryKey"`
-	Name string `json:"name"`
+	ID       uint64 `json:"id" gorm:"primaryKey"`
+	Name     string `json:"name"`
+	Category string `json:"category"`
+	Value    string `json:"value"`
 }
 
 type ProjectDetails struct {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added support for tag categories and values, allowing tags to be stored and queried as category:value pairs. Updated the database schema, models, and tag processing logic to handle the new structure.

- **Migration**
  - Adds `category` and `value` columns to the `tags` table and creates new indexes.
  - Introduces a `suite_run_tags` join table for suite-level tags.

<!-- End of auto-generated description by cubic. -->

